### PR TITLE
Use digest instead of tag to reference to an image

### DIFF
--- a/functions/source/soci-index-generator-lambda/ecrsoci/ecrsoci.go
+++ b/functions/source/soci-index-generator-lambda/ecrsoci/ecrsoci.go
@@ -144,13 +144,14 @@ func authorizeEcr(ecrRegistry *remote.Registry) error {
 }
 
 // Pull an image from the remote registry
-func (ecrSoci *EcrSoci) Pull(ctx context.Context, repositoryName string, imageTag string) (*ocispec.Descriptor, error) {
+// imageReference can be either a digest or a tag
+func (ecrSoci *EcrSoci) Pull(ctx context.Context, repositoryName string, imageReference string) (*ocispec.Descriptor, error) {
 	repo, err := ecrSoci.registry.Repository(ctx, repositoryName)
 	if err != nil {
 		return nil, err
 	}
 
-	imageDescriptor, err := oras.Copy(ctx, repo, imageTag, &ecrSoci.ociStore, imageTag, oras.DefaultCopyOptions)
+	imageDescriptor, err := oras.Copy(ctx, repo, imageReference, &ecrSoci.ociStore, imageReference, oras.DefaultCopyOptions)
 	if err != nil {
 		return nil, err
 	}

--- a/functions/source/soci-index-generator-lambda/handler.go
+++ b/functions/source/soci-index-generator-lambda/handler.go
@@ -21,25 +21,25 @@ func HandleRequest(ctx context.Context, event events.ECRImageActionEvent) (strin
 	}
 	registryUrl := buildEcrRegistryUrl(event)
 	repo := event.Detail.RepositoryName
-	tag := event.Detail.ImageTag
+	digest := event.Detail.ImageDigest
 
 	ecrSoci, err := ecrsoci.Init(ctx, registryUrl)
 	if err != nil {
 		return "", err
 	}
 
-	fmt.Printf("Pulling image [repo=%s, tag=%s]\n", repo, tag)
-	desc, err := ecrSoci.Pull(ctx, repo, tag)
+	fmt.Printf("Pulling image [repo=%s, digest=%s]\n", repo, digest)
+	desc, err := ecrSoci.Pull(ctx, repo, digest)
 	if err != nil {
 		return "", err
 	}
 
 	image := images.Image{
-		Name:   repo + ":" + tag,
+		Name:   repo + "@" + digest,
 		Target: *desc,
 	}
 
-	fmt.Printf("Building SOCI index for the image [repo=%s, tag=%s]\n", repo, tag)
+	fmt.Printf("Building SOCI index for the image [repo=%s, digest=%s]\n", repo, digest)
 	indexDescriptor, err := ecrSoci.BuildIndex(ctx, image)
 	if err != nil {
 		return "", err
@@ -51,7 +51,7 @@ func HandleRequest(ctx context.Context, event events.ECRImageActionEvent) (strin
 		return "", err
 	}
 
-	return "Successfully pushed SOCI index for " + registryUrl + "/" + repo + ":" + tag, nil
+	return "Successfully pushed SOCI index for " + registryUrl + "/" + repo + "@" + digest, nil
 }
 
 // Returns ecr registry url from an image action event


### PR DESCRIPTION
Use digest instead of tag to reference to an image

The reason is that tag might not be set by customers, so we'll miss push events where tag is omitted.