### PR TITLE
Bump SOCI from 0.4.0 to 0.4.1

### DIFF
--- a/functions/source/soci-index-generator-lambda/go.mod
+++ b/functions/source/soci-index-generator-lambda/go.mod
@@ -5,7 +5,7 @@ go 1.18
 require (
 	github.com/aws/aws-lambda-go v1.36.1
 	github.com/aws/aws-sdk-go v1.44.175
-	github.com/awslabs/soci-snapshotter v0.4.0
+	github.com/awslabs/soci-snapshotter v0.4.1
 	github.com/containerd/containerd v1.7.2
 	github.com/opencontainers/image-spec v1.1.0-rc4
 	github.com/rs/zerolog v1.29.0

--- a/functions/source/soci-index-generator-lambda/go.sum
+++ b/functions/source/soci-index-generator-lambda/go.sum
@@ -12,8 +12,8 @@ github.com/aws/aws-lambda-go v1.36.1 h1:CJxGkL9uKszIASRDxzcOcLX6juzTLoTKtCIgUGcT
 github.com/aws/aws-lambda-go v1.36.1/go.mod h1:jwFe2KmMsHmffA1X2R09hH6lFzJQxzI8qK17ewzbQMM=
 github.com/aws/aws-sdk-go v1.44.175 h1:c0NzHHnPXV5kJoTUFQxFN5cUPpX1SxO635XnwL5/oIY=
 github.com/aws/aws-sdk-go v1.44.175/go.mod h1:aVsgQcEevwlmQ7qHE9I3h+dtQgpqhFB+i8Phjh7fkwI=
-github.com/awslabs/soci-snapshotter v0.4.0 h1:dA9lOYbzSUaYMahB8qXQZTVXUszhc0w8rwjRs6EPd24=
-github.com/awslabs/soci-snapshotter v0.4.0/go.mod h1:+ST8F4E/b6b6pnFBJKprdvzkxyXODMs0FC2TmclkgJc=
+github.com/awslabs/soci-snapshotter v0.4.1 h1:f1TdTG5QZ1B6umgSPQfM1pSXDlMZu+raCKWP4QkRYL8=
+github.com/awslabs/soci-snapshotter v0.4.1/go.mod h1:faOXa3a6SsMRln4misZi82nAa4ez8Nu9i5N39kQyukY=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=


### PR DESCRIPTION
### Related Issue
Fixes #63 

### Proposed Changes
Includes notable changes to handling sparse files.

Full changelog can be found here:
https://github.com/awslabs/soci-snapshotter/releases/tag/v0.4.1

Tested it with `taskcat test run -r us-west-2 -n`, then pushed an image to my registry and confirmed that an image index and SOCI index are pushed with the image itself.

### Reviewers
@Kern-- @turan18 
