### PR TITLE
fix: Manifest Tests Failing on Redis Image

### DIFF
--- a/functions/source/soci-index-generator-lambda/utils/registry/registry.go
+++ b/functions/source/soci-index-generator-lambda/utils/registry/registry.go
@@ -30,6 +30,7 @@ import (
 const (
 	MediaTypeDockerManifestList = "application/vnd.docker.distribution.manifest.list.v2+json"
 	MediaTypeDockerManifest     = "application/vnd.docker.distribution.manifest.v2+json"
+	MediaTypeOCIImageIndex      = "application/vnd.oci.image.index.v1+json"
 	MediaTypeOCIManifest        = "application/vnd.oci.image.manifest.v1+json"
 
 	MediaTypeDockerImageConfig = "application/vnd.docker.container.image.v1+json"

--- a/functions/source/soci-index-generator-lambda/utils/registry/registry_test.go
+++ b/functions/source/soci-index-generator-lambda/utils/registry/registry_test.go
@@ -37,7 +37,7 @@ func TestHeadManifest(t *testing.T) {
 	}
 
 	expected := ExpectedResponse{
-		MediaType: MediaTypeDockerManifestList,
+		MediaType: MediaTypeOCIImageIndex,
 	}
 	doTest("public.ecr.aws", "docker/library/redis", "7", expected)
 
@@ -82,7 +82,7 @@ func TestGetManifest(t *testing.T) {
 	}
 
 	expected := ExpectedResponse{
-		MediaType: MediaTypeDockerManifestList,
+		MediaType: MediaTypeOCIImageIndex,
 		Config: ocispec.Descriptor{
 			MediaType: "",
 		},


### PR DESCRIPTION
### Related Issue
`TestHeadManifest` and `TestGetManifest` were failing as the upstream `public.ecr.aws/docker/library/redis:7` have switched from Docker Manifest Lists to OCI Image Indexes.

```
$ crane manifest public.ecr.aws/docker/library/redis:7 | jq -r '.mediaType'
application/vnd.oci.image.index.v1+json
```

See failing tests:

```
=== RUN   TestGetManifest
{"level":"info","RequestId":"abcd-1234-test-get-manifest","time":"2024-02-12T12:00:44Z","message":"Initializing registry client"}
    registry_test.go:76: Incorrect manifest media type. Expected application/vnd.docker.distribution.manifest.list.v2+json but got application/vnd.oci.image.index.v1+json
--- FAIL: TestGetManifest (0.37s)
```

### Proposed Changes
Added a new constant for the Image Index and updated the tests. I have validated locally with `make test`.

### Reviewers
Please tag the person or team responsible for reviewing this pull request, using the `@` symbol followed by their username. 
