### PR TITLE
Reduce container image size to enable taskcat upload on CloudShell (fix 1GB disk space error)

### DIFF
--- a/functions/source/soci-index-generator-lambda/Dockerfile
+++ b/functions/source/soci-index-generator-lambda/Dockerfile
@@ -14,7 +14,9 @@ WORKDIR /build
 
 COPY . .
 
-RUN make -f Makefile
+RUN --mount=type=tmpfs,target=/tmp \
+    GOCACHE=/tmp/go-cache GOTMPDIR=/tmp \
+    make -f Makefile
 
 FROM alpine
 


### PR DESCRIPTION
Hello.

I attempted to execute the upload functionality via taskcat on CloudShell, but encountered an error due to the 1GB disk space limit.

This pull request will reduce the size of the container image used for execution, enabling it to run on CloudShell.

## Error Status
```console
cfn-ecr-aws-soci-index-builder $ taskcat upload
 _            _             _   
| |_ __ _ ___| | _____ __ _| |_ 
| __/ _` / __| |/ / __/ _` | __|
| || (_| \__ \   < (_| (_| | |_ 
 \__\__,_|___/_|\_\___\__,_|\__|
                                


version 0.9.57
[INFO   ] : Packaging lambda source from /home/cloudshell-user/cfn-ecr-aws-soci-index-builder/functions/source/ecr-image-action-event-filtering without building dependencies
[INFO   ] : Packaging lambda source from /home/cloudshell-user/cfn-ecr-aws-soci-index-builder/functions/source/soci-index-generator-lambda using docker image taskcat-build-vvvvvvvvvvvvvvvvvvvvvvvvvvvvvvv
[ERROR  ] : APIError 500 Server Error for http+docker://localhost/v1.44/containers/create: Internal Server Error ("no space left on device")
cfn-ecr-aws-soci-index-builder $
```

## Post-Change Output
```console
cfn-ecr-aws-soci-index-builder $ taskcat upload
 _            _             _   
| |_ __ _ ___| | _____ __ _| |_ 
| __/ _` / __| |/ / __/ _` | __|
| || (_| \__ \   < (_| (_| | |_ 
 \__\__,_|___/_|\_\___\__,_|\__|
                                


version 0.9.57
[INFO   ] : Packaging lambda source from /home/cloudshell-user/cfn-ecr-aws-soci-index-builder/functions/source/ecr-image-action-event-filtering without building dependencies
[INFO   ] : Packaging lambda source from /home/cloudshell-user/cfn-ecr-aws-soci-index-builder/functions/source/soci-index-generator-lambda using docker image taskcat-build-vvvvvvvvvvvvvvvvvvvvvvvvvvvvvvv
[S3: -> ] [DRY_RUN] s3://tcat-xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx-ap-northeast-1/cfn-ecr-aws-soci-index-builder/NOTICE.txt
[S3: -> ] [DRY_RUN] s3://tcat-xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx-ap-northeast-1/cfn-ecr-aws-soci-index-builder/dependency-licenses.sh
[S3: -> ] [DRY_RUN] s3://tcat-xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx-ap-northeast-1/cfn-ecr-aws-soci-index-builder/THIRD_PARTY_LICENSES
[S3: -> ] [DRY_RUN] s3://tcat-xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx-ap-northeast-1/cfn-ecr-aws-soci-index-builder/CODEOWNERS
[S3: -> ] [DRY_RUN] s3://tcat-xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx-ap-northeast-1/cfn-ecr-aws-soci-index-builder/templates/SociIndexBuilder.yml
[S3: -> ] [DRY_RUN] s3://tcat-xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx-ap-northeast-1/cfn-ecr-aws-soci-index-builder/soci_index_generator_lambda.zip
[S3: -> ] [DRY_RUN] s3://tcat-xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx-ap-northeast-1/cfn-ecr-aws-soci-index-builder/LICENSE
[S3: -> ] [DRY_RUN] s3://tcat-xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx-ap-northeast-1/cfn-ecr-aws-soci-index-builder/functions/packages/ecr-image-action-event-filtering/lambda.zip
[S3: -> ] [DRY_RUN] s3://tcat-xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx-ap-northeast-1/cfn-ecr-aws-soci-index-builder/functions/packages/soci-index-generator-lambda/soci_index_generator_lambda.zip
[S3: -> ] [DRY_RUN] s3://tcat-xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx-ap-northeast-1/cfn-ecr-aws-soci-index-builder/highpoint.yml
```

## Reproduction Steps
1. Launch CloudShell
2. Run the following commands
    ```
    sudo dnf install -y python3.11-pip
    sudo pip3.11 install --no-cache-dir taskcat
    git clone --branch main --depth 1 https://github.com/awslabs/cfn-ecr-aws-soci-index-builder.git
    cd cfn-ecr-aws-soci-index-builder
    # edit .taskcat.yml
    taskcat upload
    ```