### PR TITLE
Move runtime to provided.al2023

### DIFF
--- a/templates/SociIndexBuilder.yml
+++ b/templates/SociIndexBuilder.yml
@@ -199,7 +199,7 @@ Resources:
       Description: >
         Given an Amazon ECR container repository and image, Lambda generates image SOCI artifacts and pushes to repository.
       Handler: main
-      Runtime: provided.al2
+      Runtime: provided.al2023
       Role: !GetAtt SociIndexGeneratorLambdaRole.Arn
       Timeout: 900
       Code:


### PR DESCRIPTION
### Related Issue


### Proposed Changes
AL2 is EOL June 2026. This moves our Lambda to use AL2023 instead.

### Reviewers
Please tag the person or team responsible for reviewing this pull request, using the `@` symbol followed by their username. 

### Testing
Ran `taskcat test run --region us-west-2` and confirmed I got no errors.