### PR TITLE
Generate SOCI indexes for all the supported platforms in container image

### DIFF
--- a/functions/source/soci-index-generator-lambda/handler.go
+++ b/functions/source/soci-index-generator-lambda/handler.go
@@ -338,7 +338,11 @@ func buildIndex(ctx context.Context, dataDir string, sociStore *store.SociStore,
 	// Build the SOCI index based on the specified version
 	if sociIndexVersion == "V2" {
 		// Use Convert() for V2 index generation
-		convertedOCIIndex, err := builder.Convert(ctx, image)
+		platforms, err := images.Platforms(ctx, containerdStore, image.Target)
+		if err != nil {
+			return nil, err
+		}
+		convertedOCIIndex, err := builder.Convert(ctx, image, soci.ConvertWithPlatforms(platforms...))
 		if err != nil {
 			return nil, fmt.Errorf("failed to convert OCI index: %w", err)
 		}


### PR DESCRIPTION
### Related Issue
https://github.com/awslabs/cfn-ecr-aws-soci-index-builder/issues/156
https://github.com/awslabs/soci-snapshotter/issues/1851

### Proposed Changes
This change prepares indexes for all the platforms supported by container image rather than default platform i.e. linux/amd64.

### Tested
I tested the changes e2e locally and lambda now produces multiple soci indexes when manifest contains multiple images.

1. Output of `ctr images inspect` with multiple SOCI indexes.
```
└── application/vnd.oci.image.index.v1+json @sha256:3971b299db2754c2a8ef649b45bbb3790547e7a0df17dff40c4fa1b357e6355e (2533 bytes)
    ├── application/vnd.oci.image.manifest.v1+json @sha256:db8e05a03bfd0c5b5d33a61e5389a4f7b1b453be49b507f5304b620a7b7c6391 (860 bytes)
    │   │    Platform: linux/amd64
    │   ├── application/vnd.oci.image.config.v1+json @sha256:4b6806576945570fa53d71baaee65aea99c3877d63000a758ba1d72b362cd146 (1378 bytes)
    │   ├── application/vnd.docker.image.rootfs.diff.tar.gzip @sha256:f8cdb2291c606f5df233b0eaeccd18e4307f91be55a6b2c78fa45d3a1380707a (125342 bytes)
    │   ├── application/vnd.docker.image.rootfs.diff.tar.gzip @sha256:aa95342edb7afaf1f52214d16d8b54dea0cc1e49680d6c5c299672b305471175 (125419 bytes)
    │   └── application/vnd.docker.image.rootfs.diff.tar.gzip @sha256:227e86d312006ecd2882e934ec4bbbc5b54727649bd458723b87aa91c0a8cb02 (50764904 bytes)
    ├── application/vnd.oci.image.manifest.v1+json @sha256:a900bfe5fa0dd4c06cd0d35a7c3674b450a79f34fdcddedda890feac763829d8 (860 bytes)
    │   │    Platform: linux/arm64
    │   ├── application/vnd.oci.image.config.v1+json @sha256:d5e2b1a4b12dc8f8e07fc69315c641c28f746193ab2c1a3424ac851f075f6613 (1382 bytes)
    │   ├── application/vnd.docker.image.rootfs.diff.tar.gzip @sha256:221e86c0742feb890dcf02596e4220640f462a1a2af8b261eabbd7bbdeafecf9 (125342 bytes)
    │   ├── application/vnd.docker.image.rootfs.diff.tar.gzip @sha256:0a42cc24a0ae98a141c012eef2f28f98807bddb574efefc300d4c6a878e72ab1 (125421 bytes)
    │   └── application/vnd.docker.image.rootfs.diff.tar.gzip @sha256:0ce813a8a7d9778171b65aaeb2ce5456c677d251d8b06cdfeba880c715de8664 (45680431 bytes)
    ├── application/vnd.oci.image.manifest.v1+json @sha256:1c9dd253c4f795988594559d7b9b4ab6c70ea885a85f05506eb488618679cf28 (1990 bytes)
    │   │    Platform: windows/amd64
    │   ├── application/vnd.oci.image.config.v1+json @sha256:69b6c06103edacb4fb2a5718828f645d10541c29c6b6919749146510f0f7c883 (3519 bytes)
    │   ├── application/vnd.docker.image.rootfs.diff.tar.gzip @sha256:45913f0a8ae18b9ed53b6fdc600f5062ad8ee62812c6d52c890cb122810ceb81 (126696821 bytes)
    │   ├── application/vnd.docker.image.rootfs.diff.tar.gzip @sha256:9767e378a3bca4f224302f5636009715de0fc290a8cd627ddae19129154e1eac (1031 bytes)
    │   ├── application/vnd.docker.image.rootfs.diff.tar.gzip @sha256:2eb5f094c747f04f166590b792afbe5b4d21f4d21375bf51f4048705b9499527 (1034 bytes)
    │   ├── application/vnd.docker.image.rootfs.diff.tar.gzip @sha256:452000ffb2b0df747c3ef9207a0dbae363e8eb9428e2bf8f21d08a97299a4dc7 (1031 bytes)
    │   ├── application/vnd.docker.image.rootfs.diff.tar.gzip @sha256:9b17ffa7ba81aa1163435b2b51249bddf8628f1d1c3ed7499838f6399674a030 (84802 bytes)
    │   ├── application/vnd.docker.image.rootfs.diff.tar.gzip @sha256:eb127b09083cb99e19ce374a91d76f7b5817d3992e28495da406b65d4b37dd54 (89827 bytes)
    │   ├── application/vnd.docker.image.rootfs.diff.tar.gzip @sha256:87e83b956138036a94885a2b858f2f05552ca22d89af342fca3ea5a5ece58504 (1338 bytes)
    │   ├── application/vnd.docker.image.rootfs.diff.tar.gzip @sha256:f26e03c1aeb7e77e4a636775de092f26154305899cf263b3681ed87392e80437 (53177967 bytes)
    │   ├── application/vnd.docker.image.rootfs.diff.tar.gzip @sha256:5714436f38f769e15bccfc95dc860070ec14ee8b9776f7954ed94d8a27b5c507 (1060 bytes)
    │   └── application/vnd.docker.image.rootfs.diff.tar.gzip @sha256:acb7fdc310be3b405525c95e645a2df832a99add3956ed6d3ea5496333f039c3 (1031 bytes)
    ├── application/vnd.oci.image.manifest.v1+json @sha256:1d44e303e680d00b834b5a449166771446de0f6030f4bc4a198050058857b36b (1869 bytes)
    │   │    Platform: windows/amd64
    │   ├── application/vnd.oci.image.config.v1+json @sha256:7a2086432307acfe2afa5f165dd341dddd2062c8d742dd0804e5272a9519df68 (3522 bytes)
    │   ├── application/vnd.docker.image.rootfs.diff.tar.gzip @sha256:522fa159279efd2a62d70bd5a0bc4fc8ab1ec2b1be254e8dc701beeb1211ef1b (108631300 bytes)
    │   ├── application/vnd.docker.image.rootfs.diff.tar.gzip @sha256:9dbf01450fcded7118b8a4bdef627dbbfbe4b0962f3d0bf882b626253b11bfb2 (1030 bytes)
    │   ├── application/vnd.docker.image.rootfs.diff.tar.gzip @sha256:b7a1d01c06c15a48c06f64519fc3a54eb87d10abbc9cb13486d61c713b126057 (1035 bytes)
    │   ├── application/vnd.docker.image.rootfs.diff.tar.gzip @sha256:806e9bf6438856f1f1a204ddd4a0fb23a4f33dbce9c2adad41a5d4b45c10fbd9 (1034 bytes)
    │   ├── application/vnd.docker.image.rootfs.diff.tar.gzip @sha256:a90e9c262b7cb0125577fd21142c410ba96c96ddb0e99bb79c35ccded2104913 (64018 bytes)
    │   ├── application/vnd.docker.image.rootfs.diff.tar.gzip @sha256:564fae9cca7946f53fa5e0dc21bfcc41df2d9bb9c034cebd3678afac4a179dbd (63546 bytes)
    │   ├── application/vnd.docker.image.rootfs.diff.tar.gzip @sha256:a57034f2ad41cfdd3aa222189789ab271bce014c6f26bb12f99f16ea4cf4a212 (1333 bytes)
    │   ├── application/vnd.docker.image.rootfs.diff.tar.gzip @sha256:1304e9da01e1543e0e1830072bbf93d98702b0cfa5a3fbff799a1fe2ceec42c0 (53177948 bytes)
    │   ├── application/vnd.docker.image.rootfs.diff.tar.gzip @sha256:db64aadc5a93b8f1709e15458d80f36bd0bde0a641ab615df07c3c5ea9c034a7 (1036 bytes)
    │   └── application/vnd.docker.image.rootfs.diff.tar.gzip @sha256:f9584a31940f57a2b7b6728a710cfc96a3c4cabf172aa57cf821993c32c75da6 (1037 bytes)
    ├── application/vnd.oci.image.manifest.v1+json @sha256:fc199ae6bfcc859f6255211573ab4315f0b5fcb16c087c341b8ecdd4aef18d4b (694 bytes)
    │   │    Platform: linux/amd64
    │   ├── application/vnd.amazon.soci.index.v2+json @sha256:44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a (2 bytes)
    │   └── application/octet-stream @sha256:46538d7848960039fc36f9dd4f6247f0025a947178f5c17f3cb775494020ffb2 (1481792 bytes)
    ├── application/vnd.oci.image.manifest.v1+json @sha256:493329d2af385ebd234b8ed9342a4b5d2d80249f54b08b2ac08c9d3c74d12494 (694 bytes)
    │   │    Platform: linux/arm64
    │   ├── application/vnd.amazon.soci.index.v2+json @sha256:44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a (2 bytes)
    │   └── application/octet-stream @sha256:1858b53cc3f4731a00164d9f2f449dcc713b35b40282ffbbaec1339fd2b3a37a (1383192 bytes)
    └── application/vnd.oci.image.manifest.v1+json @sha256:7f0751bd56006346da2484f6d1ce4f54db90995700aae7fa09a542906d67d1a9 (1052 bytes)
        │    Platform: windows/amd64
        ├── application/vnd.amazon.soci.index.v2+json @sha256:44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a (2 bytes)
        ├── application/octet-stream @sha256:3dd81ac003db09c7cb36f6d078a27e0ffb72bb2f62ecae9546d875da8506287b (5667776 bytes)
        └── application/octet-stream @sha256:e7ce80d31d843bb98d3b98f29444ff540010ae29afaf7f1f137b672fb2c565b0 (1559552 bytes)
```

2. ECR container image with multiple indexes
<img width="1113" height="518" alt="Screenshot 2026-03-13 at 3 45 05 PM" src="https://github.com/user-attachments/assets/2cffb82b-9e01-46b0-92a9-f98aa21206ad" />


### Reviewers
@sondavidb @henry118 
