### PR TITLE
simple build option without taskcat or AWS credentials required

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,3 +61,10 @@ parameters:
    - Pulls the image from ECR
    - Generates SOCI index artifacts using the specified version (V1 or V2)
    - Pushes the SOCI index artifacts back to ECR
+
+## Simple manual deployment
+1. Run `./build-cfn.sh`. This will build all required artifacts into the directory `./upload`
+2. Upload the contents of `./upload` to an S3 bucket
+3. Copy the Object URL of the uploaded `SociIndexBuilder.yml` template
+4. Create a new CloudFormation Stack with the Object URL of the uploaded template
+5. Test: When the Stack is created, push an image to your Elastic Container Registry. The ECR Console page should list your SOCI index. You can also take a look at the created Cloud Watch log stream to verify.

--- a/build-cfn.sh
+++ b/build-cfn.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO_ROOT="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+TARGET_DIR="${REPO_ROOT}/upload/cfn-ecr-aws-soci-index-builder"
+FUNCTIONS_SOURCE="${REPO_ROOT}/functions/source"
+FUNCTIONS_PACKAGES="${REPO_ROOT}/functions/packages"
+
+build_function() {
+  local func_name="$1"
+  local func_path="${FUNCTIONS_SOURCE}/${func_name}"
+  local output_path="${FUNCTIONS_PACKAGES}/${func_name}"
+
+  if [[ ! -d "${func_path}" ]]; then
+    echo "error: function directory not found: ${func_path}" >&2
+    return 1
+  fi
+
+  echo "Building ${func_name}..."
+
+  if [[ -f "${func_path}/Dockerfile" ]]; then
+    # Docker-based build (Go lambda)
+    local image_tag="lambda-build-$(date +%s)"
+    docker build --platform linux/amd64 -t "${image_tag}" "${func_path}" >/dev/null
+    mkdir -p "${output_path}"
+    docker run --rm --platform linux/amd64 \
+      -v "${output_path}:/output" \
+      "${image_tag}"
+    docker rmi "${image_tag}"
+    echo "  ✓ extracted to ${output_path}"
+  else
+    # Direct zip (no build)
+    mkdir -p "${output_path}"
+    cd "${func_path}"
+    zip -r "${output_path}/lambda.zip" . >/dev/null
+    cd - >/dev/null
+    echo "  ✓ zipped to ${output_path}/lambda.zip"
+  fi
+}
+
+main() {
+  mkdir -p "${FUNCTIONS_PACKAGES}"
+  for func_dir in "${FUNCTIONS_SOURCE}"/*; do
+    if [[ -d "${func_dir}" ]]; then
+      func_name=$(basename "${func_dir}")
+      build_function "${func_name}" || exit 1
+    fi
+  done
+
+  mkdir -p "${TARGET_DIR}/functions/packages"
+  cp -r "${FUNCTIONS_PACKAGES}/." "${TARGET_DIR}/functions/packages"
+  cp -r templates "${TARGET_DIR}/"
+
+  echo "Done. Upload the contents of ${TARGET_DIR} to an S3 bucket for CFN deployment."
+}
+
+main "$@"


### PR DESCRIPTION
### Related Issue
#119 #127 

### Proposed Changes
The go build of soci-index-generator-lambda requires an amd64 image to successfully compile its zlib extension. This results in compile errors when using an arm64 docker daemon, eg. Docker Desktop for macos.
taskcat uses the docker-py APIClient directly so target platform env overrides are not respected. See https://github.com/aws-ia/taskcat/blob/cb9b82b5f59f1e37b7a1caa1fbd50c79ec2264b4/taskcat/_lambda_build.py#L181, where target platform could be set (go build verified to work when patching taskcat to set `platform="linux/amd64"`).

Proposed solution is to provide an alternative to taskcat for a plain build of artifacts. This has the added benefit of not requiring exposure of AWS credentials to unvetted code (this project).

Simply builds the required artifacts, assembling them into an upload directory and lets the user deploy manually. Sidestepping taskcat makes it possible to force docker build to use an amd64 context, making this work on macos.

Pros:
* No dependencies except a Docker daemon. No need for python or taskcat.
* No unease about exposing AWS credentials to unvetted code. 
* Works on macos
 
Cons:
* User has to create an S3 bucket and upload files manually
* User has to create CFN stack manually
 
I think the Pros outweigh the Cons. 

### Reviewers
@sondavidb maybe? 
