### PR TITLE
Bump Go version in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ on:
       - '.github/workflows/ci.yml'
 
 env:
-  GO_VERSION: '1.24'
+  GO_VERSION: '1.25'
   GOLANGCI_LINT_VERSION: '2.1.6'
 
 jobs:


### PR DESCRIPTION
### Related Issue

### Proposed Changes
Upgrade Go so that we can use higher Go version in CI as 1.24 is no longer updated

### Reviewers
